### PR TITLE
Made the 250k model the default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(USE_WW)
     target_link_libraries(${TARGET_NAME} "$ENV{WW_PATH}/xs3a/U/libpryon_lite-U.a")
     add_compile_definitions(
         appconfWW_ENABLED=1
-        WW_250K=0
+        WW_250K=1
         WW_MODEL_IN_EXTMEM=0
     )
 endif()

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -44,7 +44,7 @@ your application. */
 #define configSUPPORT_STATIC_ALLOCATION         0
 #define configSUPPORT_DYNAMIC_ALLOCATION        1
 #if ON_TILE(0)
-#define configTOTAL_HEAP_SIZE                   128*1024
+#define configTOTAL_HEAP_SIZE                   116*1024
 #endif
 #if ON_TILE(1)
 #define configTOTAL_HEAP_SIZE                   128*1024

--- a/src/ww_model_runner/ww_model_runner.c
+++ b/src/ww_model_runner/ww_model_runner.c
@@ -24,8 +24,8 @@
 #if (WW_250K == 1)
 #define WW_MODEL_FILEPATH		"/flash/ww/250kenUS.bin"
 #define MODEL_RUNNER_STACK_SIZE (650)    // in WORDS
-#define DECODER_BUF_SIZE        (35000)  // (29936)  for v2.10.6
-#define WW_MAX_SIZE_BYTES       (300000) // 250k model size + 20% headroom
+#define DECODER_BUF_SIZE        (30000)  // (29936)  for v2.10.6
+#define WW_MAX_SIZE_BYTES       (233528) // 234k model size + 0% headroom
 #else
 #define WW_MODEL_FILEPATH		"/flash/ww/50kenUS.bin"
 #define MODEL_RUNNER_STACK_SIZE (650)   // in WORDS


### PR DESCRIPTION
In addition to making the large, 250kB model the default, this PR also shrunk some buffers:

- Tile[0] heap reduced from 128k to 116k
- DECODER_BUF_SIZE reduced from 35000 to 30000
- WW_MAX_SIZE_BYTES reduced from 300000 to 233528

DECODER_BUF_SIZE and WW_MAX_SIZE_BYTES may only be large enough for the 250kenUS model.

**If these buffers sizes hold up, only 2k free now on Tile[0]**