### PR TITLE
flash script should only run after successful fatfs_mkimage call

### DIFF
--- a/applications/avona/filesystem_support/flash_image.sh
+++ b/applications/avona/filesystem_support/flash_image.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-echo "creating file system..."
-./create_fs.sh
-echo "flashing firmware and filesystem..."
-xflash --quad-spi-clock 50MHz --factory ../bin/sw_avona.xe --boot-partition-size 0x100000 --data ./fat.fs
-echo "xflash complete!"
 
+echo "creating file system..."
+if ./create_fs.sh ; then
+    echo "flashing firmware and filesystem..."
+    if xflash --quad-spi-clock 50MHz --factory ../bin/sw_avona.xe --boot-partition-size 0x100000 --data ./fat.fs ; then
+        echo "xflash complete!"
+    else
+        echo "flash failed"
+    fi
+else
+    echo "file system creation failed"
+fi


### PR DESCRIPTION
the script would flash without filesystem creation success, i.e.: no path set for fatfs_mkimage