### PR TITLE
Enable AGC loss control in comms profile

### DIFF
--- a/examples/bare-metal/pipeline_multi_threaded/src/pipeline.c
+++ b/examples/bare-metal/pipeline_multi_threaded/src/pipeline.c
@@ -78,7 +78,6 @@ void pipeline_stage_2(chanend_t c_frame_in, chanend_t c_frame_out) {
     agc_config_t agc_conf_comms = AGC_PROFILE_COMMS;
     agc_conf_asr.adapt_on_vad = 0; // We don't have VAD yet
     agc_conf_comms.adapt_on_vad = 0; // We don't have VAD yet
-    agc_conf_comms.lc_enabled = 1; // Enable loss control on comms
 
     agc_state_t agc_state[AP_MAX_Y_CHANNELS];
     agc_init(&agc_state[0], &agc_conf_asr);

--- a/examples/bare-metal/pipeline_single_threaded/src/pipeline.c
+++ b/examples/bare-metal/pipeline_single_threaded/src/pipeline.c
@@ -30,7 +30,6 @@ void pipeline_init(pipeline_state_t *state) {
     agc_config_t agc_conf_comms = AGC_PROFILE_COMMS;
     agc_conf_asr.adapt_on_vad = 0; // We don't have VAD yet
     agc_conf_comms.adapt_on_vad = 0; // We don't have VAD yet
-    agc_conf_comms.lc_enabled = 1; // Enable loss control on comms
     agc_init(&state->agc_state[0], &agc_conf_asr);
     for(int ch=1; ch<AP_MAX_Y_CHANNELS; ch++) {
         agc_init(&state->agc_state[ch], &agc_conf_comms);

--- a/modules/lib_agc/api/agc_profiles.h
+++ b/modules/lib_agc/api/agc_profiles.h
@@ -67,7 +67,7 @@
     .lower_threshold = float_to_float_s32(0.4), \
     .gain_inc = float_to_float_s32(1.0034), \
     .gain_dec = float_to_float_s32(0.98804), \
-    .lc_enabled = 0, \
+    .lc_enabled = 1, \
     .lc_n_frame_far = 17, \
     .lc_n_frame_near = 34, \
     .lc_corr_threshold = float_to_float_s32(0.993), \

--- a/test/lib_agc/test_process_frame/src/test_input_output.c
+++ b/test/lib_agc/test_process_frame/src/test_input_output.c
@@ -22,16 +22,14 @@ void test_input_output() {
 
     bfp_s32_init(&input_bfp, input, FRAME_EXP, AGC_FRAME_ADVANCE, 0);
 
-    // Config and meta-data can be shared between AGC instances
-    agc_config_t conf = AGC_PROFILE_COMMS;
-    conf.lc_enabled = 1;
+    // Meta-data can be shared between AGC instances
     agc_meta_data_t md;
 
     agc_state_t agc0;
-    agc_init(&agc0, &conf);
+    agc_init(&agc0, &AGC_PROFILE_COMMS);
 
     agc_state_t agc1;
-    agc_init(&agc1, &conf);
+    agc_init(&agc1, &AGC_PROFILE_COMMS);
 
     // Random seed
     unsigned seed = 34090;

--- a/test/lib_agc/test_process_frame/src/test_lc_transitions.c
+++ b/test/lib_agc/test_process_frame/src/test_lc_transitions.c
@@ -94,7 +94,6 @@ void test_lc_transitions() {
     agc_state_t agc;
     agc_config_t conf = AGC_PROFILE_COMMS;
     conf.adapt_on_vad = 0;
-    conf.lc_enabled = 1;
 
     for (unsigned iter = 0; iter < (1<<10)/F; ++iter) {
         agc_init(&agc, &conf);

--- a/test/lib_agc/test_process_frame/src/test_loss_control.c
+++ b/test/lib_agc/test_process_frame/src/test_loss_control.c
@@ -33,7 +33,6 @@ void test_loss_control() {
     agc_state_t agc_near;
     agc_config_t conf_near = AGC_PROFILE_COMMS;
     conf_near.adapt_on_vad = 0;
-    conf_near.lc_enabled = 1;
 
     agc_meta_data_t md_near;
     md_near.vad_flag = AGC_META_DATA_NO_VAD;
@@ -42,7 +41,6 @@ void test_loss_control() {
     agc_state_t agc_far;
     agc_config_t conf_far = AGC_PROFILE_COMMS;
     conf_far.adapt_on_vad = 0;
-    conf_far.lc_enabled = 1;
 
     agc_meta_data_t md_far;
     md_far.vad_flag = AGC_META_DATA_NO_VAD;
@@ -51,7 +49,6 @@ void test_loss_control() {
     agc_state_t agc_double_talk;
     agc_config_t conf_double_talk = AGC_PROFILE_COMMS;
     conf_double_talk.adapt_on_vad = 0;
-    conf_double_talk.lc_enabled = 1;
 
     agc_meta_data_t md_double_talk;
     md_double_talk.vad_flag = AGC_META_DATA_NO_VAD;
@@ -60,7 +57,6 @@ void test_loss_control() {
     agc_state_t agc_silence;
     agc_config_t conf_silence = AGC_PROFILE_COMMS;
     conf_silence.adapt_on_vad = 0;
-    conf_silence.lc_enabled = 1;
 
     agc_meta_data_t md_silence;
     md_silence.vad_flag = AGC_META_DATA_NO_VAD;


### PR DESCRIPTION
I was always puzzled by why the comms default in lib_agc had all the loss control parameters set, but still had loss control disabled. It turns out it was supposed to be enabled by default, but that change was never merged in lib_agc. The defaults in lib_audio_pipelines have loss control enabled by default for the comms channel, so I've update the defaults in Avona to match that and removed all the unnecessary setting of "lc_enabled = 1" throughout tests and examples.