### PR TITLE
Fix link libraries for x86 build

### DIFF
--- a/examples/bare-metal/aec_1_thread/CMakeLists.txt
+++ b/examples/bare-metal/aec_1_thread/CMakeLists.txt
@@ -10,7 +10,8 @@ list( APPEND  DEP_LIBS_XCORE  ""  )
 list( APPEND  DEP_LIBS_Linux  m   )
 
 list( APPEND  DEP_LIBS        
-    lib_aec 
+    lib_aec
+    lib_xs3_math
     ${DEP_LIBS_${CMAKE_SYSTEM_NAME}}
 )
 

--- a/examples/bare-metal/pipeline_single_threaded/CMakeLists.txt
+++ b/examples/bare-metal/pipeline_single_threaded/CMakeLists.txt
@@ -12,6 +12,7 @@ list( APPEND  DEP_LIBS_Linux  m   )
 list( APPEND  DEP_LIBS        
     lib_aec
     lib_agc
+    lib_xs3_math
     ${DEP_LIBS_${CMAKE_SYSTEM_NAME}}
 )
 


### PR DESCRIPTION
[This build failure](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fsw_avona/detail/develop/85/pipeline/227) on Linux for x86 could be due to the version of cmake or the GCC toolchain. The failure was seen on sw-hw-3510-th0 (GCC 11, cmake 3.22) and I replicated in my WSL environment (GCC 10, cmake 3.22). Other Linux Jenkins agents have GCC 5, cmake 3.19. No failures have been seen on MacOS.

To test this, I've checked that the PR succeeds on different Jenkins agents: animo, sw-hw-3510-th0 and frightwig (MacOS).