### PR TITLE
Run pipelines on develop nightly only (or on demand)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -426,7 +426,7 @@ pipeline {
                 withVenv {
                   sh "./make_dirs.sh"
                   script {
-                    if (env.RUN_PIPELINE == "0") {
+                    if (env.FULL_TEST == "0") {
                       sh 'mv excluded_tests_quick.txt excluded_tests.txt'
                     }
                   }


### PR DESCRIPTION
decouple it from the full test var which works on develop/master/release