### PR TITLE
Update info in changelog for release v0.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,10 @@ XMOS Voice Framework Change Log
 -----
   
   * ADDED: Windows documentation
+  * CHANGED: Improved documentation style
   * REMOVED: VAD module
-  * CHANGED: Git hash at which lib_tflite_micro is fetched during CMake FetchContent
+  * CHANGED: Replace lib_xs3_math with the lib_xcore_math v2.1.1
+  * CHANGED: Integrate latest version of tflite-micro library in VNR module
 
 0.5.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ XMOS Voice Framework Change Log
   * CHANGED: Improved documentation style
   * REMOVED: VAD module
   * CHANGED: Replace lib_xs3_math with the lib_xcore_math v2.1.1
-  * CHANGED: Integrate latest version of tflite-micro library in VNR module
+  * CHANGED: Integrate latest version of lib_tflite_micro in VNR module
 
 0.5.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,19 @@
 XMOS Voice Framework Change Log
 ===============================
 
-0.5.1
+0.6.0
 -----
-  
-  * ADDED: Windows documentation
+
   * CHANGED: Improved documentation style
-  * REMOVED: VAD module
   * CHANGED: Replace lib_xs3_math with the lib_xcore_math v2.1.1
   * CHANGED: Integrate new version of lib_tflite_micro in VNR module
+
+0.5.1
+-----
+
+  * ADDED: Windows documentation
+  * REMOVED: VAD module
+  * CHANGED: Git hash at which lib_tflite_micro is fetched during CMake FetchContent
 
 0.5.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ XMOS Voice Framework Change Log
   * CHANGED: Improved documentation style
   * REMOVED: VAD module
   * CHANGED: Replace lib_xs3_math with the lib_xcore_math v2.1.1
-  * CHANGED: Integrate latest version of lib_tflite_micro in VNR module
+  * CHANGED: Integrate new version of lib_tflite_micro in VNR module
 
 0.5.0
 -----

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
     "title": "XCORE Voice Framework",
     "project": "fwk_voice",
-    "version": "0.5.1"
+    "version": "0.6.0"
 }


### PR DESCRIPTION
Part of #395.

The modifications in release v0.6.0 are plentiful, but mostly related to three changes:
  - documentation updates
  - update of math lib
  - update of tflite_micro_lib, which required a new API.
  
 @mbanth, I couldn't find any information about the version of tflite_micro_lib. I simply used "new version". Let me know if we can/should be more specific.
 
 @shuchitak helped me to draft the list of changes.