### PR TITLE
Remove linking to fwk_voice_module_lib_aec in CFFI tests

### DIFF
--- a/modules/lib_aec/CMakeLists.txt
+++ b/modules/lib_aec/CMakeLists.txt
@@ -33,31 +33,3 @@ target_link_libraries(fwk_voice_module_aec
 ## Create an alias
 add_library(fwk_voice::aec ALIAS fwk_voice_module_aec)
 
-
-add_library(fwk_voice_module_lib_aec STATIC)
-
-target_sources(fwk_voice_module_lib_aec
-    PRIVATE
-        src/aec_impl.c
-        src/aec_l2_impl.c
-        src/aec_priv_impl.c
-        src/aec_process_frame.c
-        src/aec_schedule_defaults.c
-)
-
-target_include_directories(fwk_voice_module_lib_aec
-    PUBLIC
-        api
-        src ## this is needed for the IC
-)
-
-target_compile_options(fwk_voice_module_lib_aec
-    PRIVATE
-        -Os
-        -g
-)
-
-target_link_libraries(fwk_voice_module_lib_aec
-    PUBLIC
-        lib_xcore_math
-)

--- a/test/lib_ic/py_c_frame_compare/build_ic_frame_proc.py
+++ b/test/lib_ic/py_c_frame_compare/build_ic_frame_proc.py
@@ -38,19 +38,17 @@ INCLUDE_DIRS=[
 
 LIBRARY_DIRS = [
     '../../../../build/modules/lib_ic',
-    '../../../../build/modules/lib_aec',
     '../../../../build/modules/lib_vnr',
     '../../../../build/fwk_voice_deps/build',
     TFLITE_MICRO_LIB_DIR
 ]
 
 LIBRARIES = [
-    'fwk_voice_module_lib_ic', 
-    'fwk_voice_module_lib_aec',
+    'fwk_voice_module_lib_ic',
     'fwk_voice_module_lib_vnr',
-    'lib_xcore_math', 
+    'lib_xcore_math',
     TFLITE_MICRO_LIB,
-    'm', 
+    'm',
     'stdc++'
 ] # on Unix, link with the math library. Linking order is important here for gcc compile on Linux!
 

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(fwk_voice_test_shared_test_utils
 
 target_include_directories(fwk_voice_test_shared_test_utils INTERFACE pseudo_rand testing)
 
-add_library(fwk_voice::test::shared::test_utils ALIAS fwk_voice_test_shared_test_utils) 
+add_library(fwk_voice::test::shared::test_utils ALIAS fwk_voice_test_shared_test_utils)
 
 #################
 
@@ -31,7 +31,7 @@ target_sources(fwk_voice_test_shared_unity INTERFACE ${UNITY_SOURCES})
 
 target_include_directories(fwk_voice_test_shared_unity
     INTERFACE
-        ${UNITY_PATH}/src 
+        ${UNITY_PATH}/src
         ${UNITY_PATH}/extras/fixture/src
         ${UNITY_PATH}/extras/memory/src)
 

--- a/test/stage_b/build_c_code.py
+++ b/test/stage_b/build_c_code.py
@@ -39,19 +39,17 @@ INCLUDE_DIRS=[
 
 LIBRARY_DIRS=[
     '../../../build/modules/lib_ic',
-    '../../../build/modules/lib_aec',
     '../../../build/modules/lib_vnr',
     '../../../build/fwk_voice_deps/build',
     TFLITE_MICRO_LIB_DIR
 ]
 
 LIBRARIES = [
-    'fwk_voice_module_lib_ic', 
-    'fwk_voice_module_lib_aec', 
-    'fwk_voice_module_lib_vnr', 
+    'fwk_voice_module_lib_ic',
+    'fwk_voice_module_lib_vnr',
     'lib_xcore_math',
-    TFLITE_MICRO_LIB, 
-    'm', 
+    TFLITE_MICRO_LIB,
+    'm',
     'stdc++'
 ] # on Unix, link with the math library. Linking order is important here for gcc compile on Linux
 


### PR DESCRIPTION
Remove fwk_voice_module_lib_aec target from modules/lib_aec/CMakeLists.txt